### PR TITLE
[DO NOT MERGE] APP-611 origin check for multiple IP's

### DIFF
--- a/integration-commons/src/main/java/org/symphonyoss/integration/exception/ExceptionMessageFormatter.java
+++ b/integration-commons/src/main/java/org/symphonyoss/integration/exception/ExceptionMessageFormatter.java
@@ -19,6 +19,7 @@ package org.symphonyoss.integration.exception;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrBuilder;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -37,7 +38,6 @@ public class ExceptionMessageFormatter {
 
   private static final String COMPONENT = "Component: ";
   private static final String MESSAGE = "Message: ";
-  private static final String ROOT_CAUSE = "Root cause: ";
   private static final String SOLUTIONS = "Solutions: ";
   private static final String STACKTRACE = "Stack trace: ";
   private static final String LINE_BREAK = "\n";
@@ -51,7 +51,6 @@ public class ExceptionMessageFormatter {
    *
    * Component: <Component>
    * Message: <Message>
-   * Stacktrace: <Trace>
    * @param component The component where the exception was thrown.
    * @param message The message why the exceptions happened.
    * @return Formatted message
@@ -68,7 +67,6 @@ public class ExceptionMessageFormatter {
    * Solutions:
    * <Solution A>
    * <Solution B>
-   * Stacktrace: <Trace>
    * @param component The component where the exception was thrown.
    * @param message The message why the exceptions happened.
    * @param solutions The solutions provided by exceptions.
@@ -79,12 +77,31 @@ public class ExceptionMessageFormatter {
     return getMessage(component, message, solutions, null);
   }
 
+
   /**
    * Formats the message following this sample:
    *
    * Component: <Component>
    * Message: <Message>
-   * Root cause: <Root cause>
+   * Solutions:
+   * <Solution A>
+   * @param component The component where the exception was thrown.
+   * @param message The message why the exceptions happened.
+   * @param solution The solution provided to the exceptions.
+   * @return Formatted message
+   */
+  public static String format(String component, String message,
+      String solution) {
+    List<String> solutions = new ArrayList<>();
+    solutions.add(solution);
+    return getMessage(component, message, solutions, null);
+  }
+
+  /**
+   * Formats the message following this sample:
+   *
+   * Component: <Component>
+   * Message: <Message>
    * Stacktrace: <Trace>
    * @param component The component where the exception was thrown.
    * @param message The message why the exceptions happened.
@@ -100,7 +117,27 @@ public class ExceptionMessageFormatter {
    *
    * Component: <Component>
    * Message: <Message>
-   * Root cause: <Root cause>
+   * Solutions:
+   * <Solution A>
+   * Stacktrace: <Trace>
+   * @param component The component where the exception was thrown.
+   * @param message The message why the exceptions happened.
+   * @param solution The solution provided by exceptions.
+   * @param t The exception caused the problem.
+   * @return Formatted message
+   */
+  public static String format(String component, String message, String solution,
+      Throwable t) {
+    List<String> solutions = new ArrayList<>();
+    solutions.add(solution);
+    return getMessage(component, message, solutions, t);
+  }
+
+  /**
+   * * Formats the message following this sample:
+   *
+   * Component: <Component>
+   * Message: <Message>
    * Solutions:
    * <Solution A>
    * <Solution B>
@@ -122,10 +159,6 @@ public class ExceptionMessageFormatter {
     sb.append(COMPONENT).appendln(StringUtils.isEmpty(component) ? UNKNOWN : component)
         .append(MESSAGE).appendln(StringUtils.isEmpty(message) ? NONE : message);
 
-    if (t != null) {
-      sb.append(ROOT_CAUSE).appendln(t.getMessage());
-    }
-
     sb.appendln(SOLUTIONS);
     if (solutions != null && !solutions.isEmpty()) {
       sb.appendWithSeparators(solutions, LINE_BREAK).appendNewLine();
@@ -133,7 +166,9 @@ public class ExceptionMessageFormatter {
       sb.appendln(NO_SOLUTION_MESSAGE);
     }
 
-    sb.append(STACKTRACE);
+    if (t != null) {
+      sb.append(STACKTRACE).appendln(t.getMessage());
+    }
 
     return sb.toString();
   }

--- a/integration-commons/src/test/java/org/symphonyoss/integration/exception/ExceptionMessageFormatterTest.java
+++ b/integration-commons/src/test/java/org/symphonyoss/integration/exception/ExceptionMessageFormatterTest.java
@@ -61,12 +61,29 @@ public class ExceptionMessageFormatterTest {
     StrBuilder expected = new StrBuilder(BREAK_LINE)
         .append(COMPONENT).appendln(COMPONENT_NAME)
         .append(MESSAGE).appendln(STR_MESSAGE)
-        .append(ROOT_CAUSE).appendln(exceptionMessage)
         .appendln(SOLUTIONS)
         .appendWithSeparators(MY_SOLUTIONS, BREAK_LINE).appendNewLine()
-        .append(STACKTRACE);
+        .append(STACKTRACE).appendln(exceptionMessage);
 
-    Assert.assertEquals(actual, expected.toString());
+    Assert.assertEquals(expected.toString(), actual);
+  }
+
+  @Test
+  public void testMessageExceptionWithThroableOneSolution() {
+    String exceptionMessage = "Something is null";
+    NullPointerException exception = new NullPointerException(exceptionMessage);
+    String actual = ExceptionMessageFormatter.format(COMPONENT_NAME, STR_MESSAGE, SOLUTION,
+        exception
+    );
+
+    StrBuilder expected = new StrBuilder(BREAK_LINE)
+        .append(COMPONENT).appendln(COMPONENT_NAME)
+        .append(MESSAGE).appendln(STR_MESSAGE)
+        .appendln(SOLUTIONS)
+        .appendln(SOLUTION)
+        .append(STACKTRACE).appendln(exceptionMessage);
+
+    Assert.assertEquals(expected.toString(), actual);
   }
 
   @Test
@@ -78,10 +95,22 @@ public class ExceptionMessageFormatterTest {
         .append(COMPONENT).appendln(COMPONENT_NAME)
         .append(MESSAGE).appendln(STR_MESSAGE)
         .appendln(SOLUTIONS)
-        .appendWithSeparators(MY_SOLUTIONS, BREAK_LINE).appendNewLine()
-        .append(STACKTRACE);
+        .appendWithSeparators(MY_SOLUTIONS, BREAK_LINE).appendNewLine();
 
-    Assert.assertEquals(actual, expected.toString());
+    Assert.assertEquals(expected.toString(), actual);
+  }
+
+  @Test
+  public void testMessageExceptionWithoutThroableOneSolution() {
+    String actual = ExceptionMessageFormatter.format(COMPONENT_NAME, STR_MESSAGE, SOLUTION);
+
+    StrBuilder expected = new StrBuilder(BREAK_LINE)
+        .append(COMPONENT).appendln(COMPONENT_NAME)
+        .append(MESSAGE).appendln(STR_MESSAGE)
+        .appendln(SOLUTIONS)
+        .appendln(SOLUTION);
+
+    Assert.assertEquals(expected.toString(), actual);
   }
 
   @Test
@@ -92,8 +121,7 @@ public class ExceptionMessageFormatterTest {
         .append(COMPONENT).appendln(COMPONENT_NAME)
         .append(MESSAGE).appendln(STR_MESSAGE)
         .appendln(SOLUTIONS)
-        .appendln(NO_SOLUTION_MESSAGE)
-        .append(STACKTRACE);
+        .appendln(NO_SOLUTION_MESSAGE);
 
     Assert.assertEquals(actual, expected.toString());
   }
@@ -106,10 +134,9 @@ public class ExceptionMessageFormatterTest {
         .append(COMPONENT).appendln(UNKNOWN)
         .append(MESSAGE).appendln(NONE)
         .appendln(SOLUTIONS)
-        .appendln(NO_SOLUTION_MESSAGE)
-        .append(STACKTRACE);
+        .appendln(NO_SOLUTION_MESSAGE);
 
-    Assert.assertEquals(actual, expected.toString());
+    Assert.assertEquals(expected.toString(), actual);
   }
 
   @Test
@@ -120,10 +147,9 @@ public class ExceptionMessageFormatterTest {
         .append(COMPONENT).appendln(UNKNOWN)
         .append(MESSAGE).appendln(NONE)
         .appendln(SOLUTIONS)
-        .appendln(NO_SOLUTION_MESSAGE)
-        .append(STACKTRACE);
+        .appendln(NO_SOLUTION_MESSAGE);
 
-    Assert.assertEquals(actual, expected.toString());
+    Assert.assertEquals(expected.toString(), actual);
   }
 
 }


### PR DESCRIPTION
Support multiple IP's on the x-forwarded-for header.

This PR is just adding new support on the log message formatter to allow logging messages with a single solution passed as string instead of single item collection.