### PR TITLE
Group Id and Optional Provisioning Build

### DIFF
--- a/integration-api-client/pom.xml
+++ b/integration-api-client/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>integration-parent</artifactId>
-        <groupId>org.symphonyoss</groupId>
+        <groupId>org.symphonyoss.symphony.integrations</groupId>
         <version>0.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -13,13 +13,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.symphonyoss</groupId>
+            <groupId>org.symphonyoss.symphony.integrations</groupId>
             <artifactId>integration-commons</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.symphonyoss</groupId>
+            <groupId>org.symphonyoss.symphony.integrations</groupId>
             <artifactId>integration-metrics</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/integration-commons/pom.xml
+++ b/integration-commons/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>integration-parent</artifactId>
-        <groupId>org.symphonyoss</groupId>
+        <groupId>org.symphonyoss.symphony.integrations</groupId>
         <version>0.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/integration-metrics/pom.xml
+++ b/integration-metrics/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>integration-parent</artifactId>
-        <groupId>org.symphonyoss</groupId>
+        <groupId>org.symphonyoss.symphony.integrations</groupId>
         <version>0.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/integration-webhook/pom.xml
+++ b/integration-webhook/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>integration-parent</artifactId>
-        <groupId>org.symphonyoss</groupId>
+        <groupId>org.symphonyoss.symphony.integrations</groupId>
         <version>0.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -13,19 +13,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.symphonyoss</groupId>
+            <groupId>org.symphonyoss.symphony.integrations</groupId>
             <artifactId>integration-commons</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.symphonyoss</groupId>
+            <groupId>org.symphonyoss.symphony.integrations</groupId>
             <artifactId>integration-metrics</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.symphonyoss</groupId>
+            <groupId>org.symphonyoss.symphony.integrations</groupId>
             <artifactId>integration-commons</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <version>3</version>
     </parent>
 
-    <groupId>org.symphonyoss</groupId>
+    <groupId>org.symphonyoss.symphony.integrations</groupId>
     <artifactId>integration-parent</artifactId>
     <version>0.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
Changing the artifact group id to org.symphonyoss.symphony.integration; adding support to optionally build the provisioning tool.