### PR TITLE
Local run

### DIFF
--- a/integration-api-client/pom.xml
+++ b/integration-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-parent</artifactId>
         <groupId>org.symphonyoss</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-commons/pom.xml
+++ b/integration-commons/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-parent</artifactId>
         <groupId>org.symphonyoss</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-metrics/pom.xml
+++ b/integration-metrics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-parent</artifactId>
         <groupId>org.symphonyoss</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-webhook/pom.xml
+++ b/integration-webhook/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-parent</artifactId>
         <groupId>org.symphonyoss</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-webhook/pom.xml
+++ b/integration-webhook/pom.xml
@@ -5,7 +5,6 @@
     <parent>
         <artifactId>integration-parent</artifactId>
         <groupId>org.symphonyoss</groupId>
-        <version>0.9.0-SNAPSHOT</version>
         <version>0.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -606,6 +606,80 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>run</id>
+            <build>
+                <finalName>integration</finalName>
+                <plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-shade-plugin</artifactId>
+                      <version>3.0.0</version>
+                      <configuration>
+                        <createDependencyReducedPom>false</createDependencyReducedPom>
+                      </configuration>
+                      <executions>
+                        <execution>
+                          <phase>package</phase>
+                          <goals>
+                            <goal>shade</goal>
+                          </goals>
+                        </execution>
+                      </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <version>${spring.boot.version}</version>
+                        <configuration>
+                            <layout>ZIP</layout>
+                            <mainClass>org.symphonyoss.integration.web.IntegrationBridgeApplication</mainClass>
+                            <includes>
+                              <include>
+                                <groupId>org.symphonyoss</groupId>
+                                <artifactId>integration-web</artifactId>
+                              </include>
+                            </includes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>repackage</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.symphonyoss</groupId>
+                    <artifactId>integration-web</artifactId>
+                    <version>${project.version}</version>
+                    <!--
+                    TODO - would be better if integration-web defined optional deps; see more on
+                    https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html
+                    -->
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.symphonyoss</groupId>
+                    <artifactId>integration-core</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,36 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.1.RELEASE</version>
+        <groupId>org.symphonyoss</groupId>
+        <artifactId>symphonyoss</artifactId>
+        <version>3</version>
     </parent>
 
     <groupId>org.symphonyoss</groupId>
     <artifactId>integration-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
+    <description>Core components for Symphony App Integrations</description>
+    <url>https://github.com/symphonyoss/App-Integrations-Core</url>
+
+    <licenses>
+      <license>
+        <name>Apache License, Version 2.0</name>
+        <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      </license>
+    </licenses>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <!-- Import dependency management from Spring Boot -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>1.5.1.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-client</artifactId>
@@ -476,9 +494,9 @@
     </ciManagement>
 
     <scm>
-        <connection>scm:git:https://github.com/SymphonyOSF/Integration</connection>
-        <developerConnection>scm:git:https://github.com/SymphonyOSF/Integration/</developerConnection>
-        <url>scm:git:https://github.com/SymphonyOSF/Integration</url>
+      <connection>scm:git:git://github.com/symphonyoss/App-Integrations-Commons.git</connection>
+      <developerConnection>scm:git:git@github.com:symphonyoss/App-Integrations-Commons.git</developerConnection>
+      <url>https://github.com/symphonyoss/App-Integrations-Commons</url>
     </scm>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <version>0.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <description>Core components for Symphony App Integrations</description>
-    <url>https://github.com/symphonyoss/App-Integrations-Core</url>
+    <description>Common components for Symphony App Integrations</description>
+    <url>https://github.com/symphonyoss/App-Integrations-Commons</url>
 
     <licenses>
       <license>

--- a/pom.xml
+++ b/pom.xml
@@ -616,7 +616,16 @@
                       <artifactId>maven-shade-plugin</artifactId>
                       <version>3.0.0</version>
                       <configuration>
-                        <createDependencyReducedPom>false</createDependencyReducedPom>
+                          <createDependencyReducedPom>false</createDependencyReducedPom>
+                          <artifactSet>
+                              <includes>
+                                  <include>org.symphonyoss.symphony.integrations:integration-web</include>
+                              </includes>
+                              <excludes>
+                                  <exclude>org.springframework.boot:*</exclude>
+                                  <exclude>org.symphonyoss.symphony.integrations:integration-webhook</exclude>
+                              </excludes>
+                          </artifactSet>
                       </configuration>
                       <executions>
                         <execution>
@@ -635,12 +644,12 @@
                         <configuration>
                             <layout>ZIP</layout>
                             <mainClass>org.symphonyoss.integration.web.IntegrationBridgeApplication</mainClass>
-                            <includes>
-                              <include>
-                                <groupId>org.symphonyoss</groupId>
-                                <artifactId>integration-web</artifactId>
-                              </include>
-                            </includes>
+                            <excludes>
+                                <exclude>
+                                    <groupId>org.symphonyoss.symphony.integrations</groupId>
+                                    <artifactId>integration-web</artifactId>
+                                </exclude>
+                            </excludes>
                         </configuration>
                         <executions>
                             <execution>
@@ -655,28 +664,9 @@
 
             <dependencies>
                 <dependency>
-                    <groupId>org.symphonyoss</groupId>
+                    <groupId>org.symphonyoss.symphony.integrations</groupId>
                     <artifactId>integration-web</artifactId>
                     <version>${project.version}</version>
-                    <!--
-                    TODO - would be better if integration-web defined optional deps; see more on
-                    https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html
-                    -->
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.symphonyoss</groupId>
-                    <artifactId>integration-core</artifactId>
-                    <version>${project.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-web</artifactId>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
Added -Prun Maven profile to `integration-parent` pom.xml; the idea is to use this profile from an integration project that is built from scratch.

The profile creates a bundle with [integration-web jar](https://oss.sonatype.org/content/repositories/snapshots/org/symphonyoss/symphony/integrations/integration-web/0.10.0-SNAPSHOT/) and the project classes.

Currently the implementation runs the bundle, but spring boot doesn't find the integration class.

As an example of integration project built from scratch (precisely, as a fork of the universal integration), checkout the [evandro's sample integration](https://github.com/ecarrenho-daitan/App-Integrations-HubSpot/tree/hubspot) and the [run.sh script](https://github.com/ecarrenho-daitan/App-Integrations-HubSpot/blob/hubspot/run.sh), that is supposed to be what developers run locally.