### PR TITLE
APP-1012 Multipart/form-data doesn't work properly with Apache Connector Provider

### DIFF
--- a/integration-api-client/src/main/java/org/symphonyoss/integration/api/client/SimpleHttpApiClient.java
+++ b/integration-api-client/src/main/java/org/symphonyoss/integration/api/client/SimpleHttpApiClient.java
@@ -44,6 +44,10 @@ public class SimpleHttpApiClient implements HttpApiClient {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SimpleHttpApiClient.class);
 
+  private static final String DEFAULT_MIME_VERSION_HEADER = "1.0";
+
+  private static final String MIME_VERSION_HEADER = "MIME-Version";
+
   /**
    * JSON helper class
    */
@@ -179,6 +183,8 @@ public class SimpleHttpApiClient implements HttpApiClient {
         invocationBuilder = invocationBuilder.header(entry.getKey(), entry.getValue());
       }
     }
+
+    invocationBuilder.header(MIME_VERSION_HEADER, DEFAULT_MIME_VERSION_HEADER);
 
     return invocationBuilder;
   }

--- a/integration-api-client/src/main/java/org/symphonyoss/integration/api/client/form/MultiPartEntitySerializer.java
+++ b/integration-api-client/src/main/java/org/symphonyoss/integration/api/client/form/MultiPartEntitySerializer.java
@@ -18,6 +18,7 @@ package org.symphonyoss.integration.api.client.form;
 
 import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA_TYPE;
 
+import org.glassfish.jersey.media.multipart.Boundary;
 import org.symphonyoss.integration.api.client.EntitySerializer;
 import org.symphonyoss.integration.exception.RemoteApiException;
 
@@ -32,7 +33,7 @@ public class MultiPartEntitySerializer implements EntitySerializer {
 
   @Override
   public Entity serialize(Object input) throws RemoteApiException {
-    return Entity.entity(input, MULTIPART_FORM_DATA_TYPE);
+    return Entity.entity(input, Boundary.addBoundary(MULTIPART_FORM_DATA_TYPE));
   }
 
 }

--- a/integration-api-client/src/test/java/org/symphonyoss/integration/api/client/form/MultiPartEntitySerializerTest.java
+++ b/integration-api-client/src/test/java/org/symphonyoss/integration/api/client/form/MultiPartEntitySerializerTest.java
@@ -18,7 +18,9 @@ package org.symphonyoss.integration.api.client.form;
 
 import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA_TYPE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
+import org.glassfish.jersey.media.multipart.Boundary;
 import org.glassfish.jersey.media.multipart.MultiPart;
 import org.junit.Test;
 import org.symphonyoss.integration.exception.RemoteApiException;
@@ -42,8 +44,10 @@ public class MultiPartEntitySerializerTest {
 
     Entity result = serializer.serialize(input);
 
-    Entity<MultiPart> expected = Entity.entity(input, MULTIPART_FORM_DATA_TYPE);
+    MediaType mediaType = result.getMediaType();
 
-    assertEquals(expected, result);
+    assertEquals(MULTIPART_FORM_DATA_TYPE, new MediaType(mediaType.getType(), mediaType.getSubtype()));
+    assertNotNull(mediaType.getParameters().get(Boundary.BOUNDARY_PARAMETER));
+    assertEquals(input, result.getEntity());
   }
 }


### PR DESCRIPTION
When the Jersey Client uses the Apache Connector Provider to build the HTTP connections the requests that have content type 'multipart/form-data' doesn't work because the 'content-type' header have no boundary defined.

**HttpUrlConnector**
Content-Type: multipart/form-data;boundary=Boundary_1_1763917409_1493746375502
User-Agent: Jersey/2.25.1 (HttpUrlConnection 1.7.0_80)

---

**Apache HTTP client**
Content-Type: multipart/form-data
User-Agent: Jersey/2.25.1 (Apache HttpClient 4.5.2)

---

**Related links**:
https://java.net/jira/browse/JERSEY-2123
https://java.net/jira/browse/JERSEY-2341