### PR TITLE
APP-1021 Add Webhook Owner information to JSON Entity (Message ML v2)

### DIFF
--- a/integration-webhook/src/main/java/org/symphonyoss/integration/webhook/WebHookIntegration.java
+++ b/integration-webhook/src/main/java/org/symphonyoss/integration/webhook/WebHookIntegration.java
@@ -286,7 +286,7 @@ public abstract class WebHookIntegration extends BaseIntegration {
       if (StringUtils.isEmpty(data)) {
         dataNode = JsonNodeFactory.instance.objectNode();
       } else {
-        dataNode = (ObjectNode) JsonUtils.readTree(message.getData());
+        dataNode = (ObjectNode) JsonUtils.readTree(data);
       }
 
       ObjectNode ownership = dataNode.putObject(OWNERSHIP);
@@ -299,7 +299,7 @@ public abstract class WebHookIntegration extends BaseIntegration {
         ownership.put(USER_NAME, creatorName);
       }
 
-      String newData = JsonUtils.writeValueAsString(data);
+      String newData = JsonUtils.writeValueAsString(dataNode);
       message.setData(newData);
     } catch (Exception e) {
       LOGGER.warn("Fail to set ownership info for instance " + instance.getInstanceId(), e);

--- a/integration-webhook/src/main/java/org/symphonyoss/integration/webhook/WebHookIntegration.java
+++ b/integration-webhook/src/main/java/org/symphonyoss/integration/webhook/WebHookIntegration.java
@@ -22,7 +22,6 @@ import static org.symphonyoss.integration.model.healthcheck.IntegrationFlags.Val
 import static org.symphonyoss.integration.utils.WebHookConfigurationUtils.LAST_POSTED_DATE;
 
 import com.codahale.metrics.Timer;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
@@ -43,13 +42,13 @@ import org.symphonyoss.integration.exception.config.IntegrationConfigException;
 import org.symphonyoss.integration.json.JsonUtils;
 import org.symphonyoss.integration.model.config.IntegrationInstance;
 import org.symphonyoss.integration.model.config.IntegrationSettings;
+import org.symphonyoss.integration.model.healthcheck.IntegrationHealth;
 import org.symphonyoss.integration.model.message.Message;
 import org.symphonyoss.integration.model.message.MessageMLVersion;
 import org.symphonyoss.integration.model.stream.StreamType;
-import org.symphonyoss.integration.model.healthcheck.IntegrationHealth;
 import org.symphonyoss.integration.model.yaml.Application;
-import org.symphonyoss.integration.service.IntegrationService;
 import org.symphonyoss.integration.service.IntegrationBridge;
+import org.symphonyoss.integration.service.IntegrationService;
 import org.symphonyoss.integration.service.StreamService;
 import org.symphonyoss.integration.service.UserService;
 import org.symphonyoss.integration.utils.WebHookConfigurationUtils;
@@ -61,9 +60,6 @@ import org.symphonyoss.integration.webhook.exception.WebHookUnavailableException
 import org.symphonyoss.integration.webhook.exception.WebHookUnprocessableEntityException;
 import org.symphonyoss.integration.webhook.metrics.ParserMetricsController;
 
-import javax.ws.rs.core.MediaType;
-import javax.xml.parsers.ParserConfigurationException;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
@@ -72,6 +68,8 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.core.MediaType;
 
 /**
  * WebHook based Integrations, implementing common methods for WebHookIntegrations and defining

--- a/integration-webhook/src/test/java/org/symphonyoss/integration/webhook/V2MockWebHookIntegration.java
+++ b/integration-webhook/src/test/java/org/symphonyoss/integration/webhook/V2MockWebHookIntegration.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2016-2017 Symphony Integrations - Symphony LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.symphonyoss.integration.webhook;
+
+import static org.symphonyoss.integration.messageml.MessageMLFormatConstants.MESSAGEML_END;
+import static org.symphonyoss.integration.messageml.MessageMLFormatConstants.MESSAGEML_START;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.context.annotation.Scope;
+import org.symphonyoss.integration.json.JsonUtils;
+import org.symphonyoss.integration.model.message.Message;
+import org.symphonyoss.integration.model.message.MessageMLVersion;
+import org.symphonyoss.integration.webhook.exception.WebHookParseException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Mock class for {@link WebHookIntegration}
+ * Created by rsanchez on 10/08/16.
+ */
+@TestComponent
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class V2MockWebHookIntegration extends WebHookIntegration {
+
+  public static final String MESSAGE = "message";
+
+  public static final String DATA = "data";
+
+  @Override
+  public Message parse(WebHookPayload input) throws WebHookParseException {
+    String formattedMessage;
+    String data;
+
+    try {
+      JsonNode rootNode = JsonUtils.readTree(input.getBody());
+      formattedMessage = rootNode.path(MESSAGE).asText();
+
+      JsonNode dataNode = rootNode.path(DATA);
+
+      if (dataNode.isObject()) {
+        data = JsonUtils.writeValueAsString(dataNode);
+      } else {
+        data = dataNode.asText();
+      }
+    } catch (IOException e) {
+      throw new WebHookParseException(getClass().getName(), "Fail parse incoming message");
+    }
+
+    StringBuilder messageBuilder = new StringBuilder(MESSAGEML_START);
+    messageBuilder.append(formattedMessage);
+    messageBuilder.append(MESSAGEML_END);
+
+    Message message = new Message();
+    message.setMessage(messageBuilder.toString());
+
+    if (StringUtils.isNotEmpty(data)) {
+      message.setData(data);
+    }
+
+    message.setVersion(MessageMLVersion.V2);
+
+    return message;
+  }
+
+  /**
+   * @see WebHookIntegration#getSupportedContentTypes()
+   */
+  @Override
+  public List<MediaType> getSupportedContentTypes() {
+    List<MediaType> supportedContentTypes = new ArrayList<>();
+    supportedContentTypes.add(MediaType.WILDCARD_TYPE);
+    return supportedContentTypes;
+  }
+}


### PR DESCRIPTION
- In order to support compliance officers on tracking the owners for webhook messages, the JSON Entity should contain the username and userId for the webhook owner. This information is not displayed as part of the message, it is just carried within the JSON entity.