### PR TITLE
Set version cobertura to 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -855,7 +855,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>2.7</version>
+                        <version>2.6</version>
                         <configuration>
                             <formats>
                                 <format>html</format>


### PR DESCRIPTION
Returning version cobertura for 2.6, because version 2.7 have a bug for maven multi project.