### PR TITLE
:new: extend the maven bundle profile to generate a bundle folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,10 @@ To start from scratch, do the following:
 1. Clone the source repository using Git: `git clone git@github.com:symphonyoss/App-Integrations-Commons.git`
 2. cd into _App-Integrations-Commons_
 3. Build using maven: `mvn clean install`
+
+#### Creating a bundle
+
+In order to distribute and/or deploy an Integration, the Maven build provides a `-Pbundle` profile which creates a `target/bundle` folder containing:
+- an `integration.jar` artifact including all Java logic needed
+- an `application.yaml` file that configures the Spring Boot application; the file must be located in the project's root folder
+- a `run.sh` that is able to run the integration on different platforms (locally and remotely); the file must be located in the project's root folder

--- a/pom.xml
+++ b/pom.xml
@@ -777,7 +777,7 @@
         </profile>
 
         <profile>
-            <id>run</id>
+            <id>bundle</id>
             <build>
                 <finalName>integration</finalName>
                 <plugins>
@@ -828,6 +828,41 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+
+                    <plugin>
+                      <artifactId>maven-resources-plugin</artifactId>
+                      <version>3.0.2</version>
+                      <executions>
+                        <execution>
+                          <id>copy-resources</id>
+                          <phase>verify</phase>
+                          <goals>
+                            <goal>copy-resources</goal>
+                          </goals>
+                          <configuration>
+                            <nonFilteredFileExtensions>
+                              <nonFilteredFileExtension>jar</nonFilteredFileExtension>
+                            </nonFilteredFileExtensions>
+                            <outputDirectory>${project.build.directory}/bundle</outputDirectory>
+                            <resources>
+                              <resource>
+                                <directory>${project.build.directory}</directory>
+                                <includes>
+                                  <include>integration.jar</include>
+                                </includes>
+                              </resource>
+                              <resource>
+                                <directory>.</directory>
+                                <includes>
+                                  <include>application.yaml</include>
+                                  <include>run.sh</include>
+                                </includes>
+                              </resource>
+                            </resources>
+                          </configuration>
+                        </execution>
+                      </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
The `target/bundle` folder is ready to be deployed remotely, or used to run the integration locally.