### PR TITLE
Fix authorization unit tests

### DIFF
--- a/integration-authorization/src/test/java/org/symphonyoss/integration/authorization/oauth/v1/OAuth1GetAccessTokenTest.java
+++ b/integration-authorization/src/test/java/org/symphonyoss/integration/authorization/oauth/v1/OAuth1GetAccessTokenTest.java
@@ -28,13 +28,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.symphonyoss.integration.authorization.oauth.OAuthRsaSignerFactory;
 import org.symphonyoss.integration.utils.RsaKeyUtils;
 
-import java.net.UnknownHostException;
+import java.io.IOException;
 
 /**
  * Unit tests for {@link OAuth1GetAccessToken}.
@@ -61,7 +60,7 @@ public class OAuth1GetAccessTokenTest {
     assertEquals(StringUtils.EMPTY, token.verifier);
   }
 
-  @Test(expected = UnknownHostException.class)
+  @Test(expected = IOException.class)
   public void testInvalidExecution() throws Exception {
     OAuthRsaSigner rsaSigner = rsaSignerFactory.getOAuthRsaSigner(PRIVATE_KEY);
     OAuth1GetAccessToken token = new OAuth1GetAccessToken(

--- a/integration-authorization/src/test/java/org/symphonyoss/integration/authorization/oauth/v1/OAuth1GetTemporaryTokenTest.java
+++ b/integration-authorization/src/test/java/org/symphonyoss/integration/authorization/oauth/v1/OAuth1GetTemporaryTokenTest.java
@@ -28,13 +28,12 @@ import com.google.api.client.auth.oauth.OAuthRsaSigner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.symphonyoss.integration.authorization.oauth.OAuthRsaSignerFactory;
 import org.symphonyoss.integration.utils.RsaKeyUtils;
 
-import java.net.UnknownHostException;
+import java.io.IOException;
 
 /**
  * Unit tests for {@link OAuth1GetTemporaryToken}.
@@ -60,7 +59,7 @@ public class OAuth1GetTemporaryTokenTest {
     assertEquals(AUTHORIZATION_CALLBACK_URL.toString(), token.callback);
   }
 
-  @Test(expected = UnknownHostException.class)
+  @Test(expected = IOException.class)
   public void testInvalidExecution() throws Exception {
     OAuthRsaSigner rsaSigner = rsaSignerFactory.getOAuthRsaSigner(PRIVATE_KEY);
     OAuth1GetTemporaryToken token = new OAuth1GetTemporaryToken(


### PR DESCRIPTION
- Unit tests are not deterministics. The exception raised by the component can vary according to the network topology.